### PR TITLE
Allow to configure api host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ init.dist:
 	@pip install -r requirements/dist.txt
 
 init: init.test init.dist
-	@pip install -r requirements/local.txt
+	@pip install -r requirements/base.txt
 
 test:
 	@$(PYTEST) --verbose $(tests)

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Usage
 .. code:: python
 
     >>> import quaderno_sdk
-    >>> client = quaderno_sdk.Client('api_key', 'account_name')
+    >>> client = quaderno_sdk.Client('api_key', 'api_host')
     >>> r = client.invoices()
     >>> r.json()
     [

--- a/quaderno_sdk/__init__.py
+++ b/quaderno_sdk/__init__.py
@@ -15,7 +15,7 @@
 #  0. You just DO WHAT THE FUCK YOU WANT TO.
 
 
-__version__ = '0.0.1'
+__version__ = '0.0.2'
 
 import json
 import requests
@@ -73,18 +73,23 @@ class Client(object):
 
     user_agent = 'QuadernoSdk/api-rest-sdk:' + __version__
 
-    def __init__(self, token, account_name, version='1', ctype='json'):
+    def __init__(self, token, api_host, version=None, ctype='json'):
 
         self.token = token
-        self.version = version
         self.ctype = ctype
-        self.host = "https://{}.quadernoapp.com".format(account_name)
+        self.version = version
+        self.host = api_host
 
     @property
     def headers(self):
-        return {
+        headers = {
             'User-Agent': self.user_agent
         }
+        if self.version:
+            headers.update({
+                'Accept': 'application/json',
+                'api_version': self.version})
+        return headers
 
     def request(self, url, method, headers=None, **kwargs):
         http_headers = self.headers
@@ -103,7 +108,7 @@ class Client(object):
 
     def _endpoint(self, action, method, **kwargs):
         return self.request(
-            "{self.host}/api/v{self.version}/{action}.{self.ctype}"
+            "{self.host}/api/{action}.{self.ctype}"
             .format(self=self, action=action), method, **kwargs)
 
     def get(self, action, params=None, **kwargs):

--- a/tests/base.py
+++ b/tests/base.py
@@ -8,7 +8,7 @@ class SdkBaseTestCase(unittest.TestCase):
 
     def setUp(self):
         self.client = quaderno_sdk.Client(
-            token=self.token, account_name=self.account_name)
+            token=self.token, api_host=self.api_host)
 
     def tearDown(self):
         pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 @pytest.fixture(scope='class')
 def conf_class(request):
     request.cls.token = request.config.option.token
-    request.cls.account_name = request.config.option.account_name
+    request.cls.api_host = request.config.option.api_host
 
 
 def pytest_addoption(parser):
@@ -14,6 +14,6 @@ def pytest_addoption(parser):
         help='API token')
 
     parser.addoption(
-        '--account-name',
-        dest='account_name',
-        help='Quaderno account name')
+        '--api-host',
+        dest='api_host',
+        help='API host')


### PR DESCRIPTION
Permite configurar el host de la API para poder usar el modo sandbox y la versión de la API como header en las peticiones.